### PR TITLE
Fix regex special chars escaping in search

### DIFF
--- a/front-end/src/utils/resource-api-utils.js
+++ b/front-end/src/utils/resource-api-utils.js
@@ -69,17 +69,23 @@ function searchBy({ data, keywords, tags }) {
   };
 
   const checkMatchKeywords = (name) => {
-    const kewordsToRegExpStr = `${sanitizedKeywords
+    const escapeRegex = (string) => {
+      return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    };
+
+    const escapedKeywords = escapeRegex(sanitizedKeywords);
+
+    const keywordsToRegExpStr = `${sanitizedKeywords
       .split(" ")
       .map((word) =>
-        word.length >= 3 ? `(${word.slice(0, 3)})${word.slice(3)}` : word
+        word.length >= 3 ? `(${escapeRegex(word.slice(0, 3))})${escapeRegex(word.slice(3))}` : escapeRegex(word)
       )
       .join("|")}`;
 
     const nameKeywordsArr = name.split(" ");
 
     const keywordsRegEx = new RegExp(
-      `${sanitizedKeywords}|${kewordsToRegExpStr}`,
+      `${escapedKeywords}|${keywordsToRegExpStr}`,
       "gm"
     );
 


### PR DESCRIPTION
- Problem: Searches with special chars like [, (, ), *, etc., are crashing the app because they have special regex meaning.
- Solution: Added escaping to treat special chars as literal text instead of regex, as this better meets the needs of our dev audience who may be searching with special chars.