### PR TITLE
Corrected bug with tag pills when 8 tags were selected

### DIFF
--- a/front-end/src/components/SearchBar.jsx
+++ b/front-end/src/components/SearchBar.jsx
@@ -84,10 +84,6 @@ export default function SearchBar() {
     const tagId = e.target.value;
     const tagName = e.target.textContent;
 
-    if (activeTags.length >= 8) {
-      return;
-    }
-
     baseHandleTagsInput(e);
   };
 

--- a/front-end/src/hooks/useSearchResources.js
+++ b/front-end/src/hooks/useSearchResources.js
@@ -30,6 +30,8 @@ export default function useSearchResources({ resources, tags, isFetching }) {
       const filteredTags = activeTags.filter(({ id }) => id !== tagId);
       searchInputRef.current.focus();
       return setActiveTags(filteredTags);
+    } else if (activeTags.length >= 8) {
+      return;
     }
     searchInputRef.current.focus();
     setActiveTags((oldState) => [...oldState, { id: tagId, name: tagName }]);


### PR DESCRIPTION
There was a bug preventing the ability to remove tags individually when all 8 were selected. The fix was moving an if statement from the SearchBar.jsx component into the useSearchResources.js component and the base function of handleTagsInput.