### PR TITLE
Bug fix. Pagination menu consistently visible

### DIFF
--- a/front-end/src/components/ResultsComponent/ResultsContainer.jsx
+++ b/front-end/src/components/ResultsComponent/ResultsContainer.jsx
@@ -79,7 +79,7 @@ export default function ResultsContainer({className}) {
 
   return (
     <section className={className}>
-      <div className="flex flex-col w-svw max-[380px]:h-[65svh] min-[390px]:h-[70svh] md:h-[74svh] xl:h-[70svh]">
+      <div className="flex flex-col w-svw max-[380px]:h-[63svh] min-[381px]:h-[63svh] md:h-[65svh] xl:h-[65svh]">
         {!results ? (
           <LoadingIndicator />
         ) : results.error ? (

--- a/front-end/src/components/SearchBar.jsx
+++ b/front-end/src/components/SearchBar.jsx
@@ -12,7 +12,6 @@ export default function SearchBar() {
   const [errors, setErrors] = useState({ searchText: "" });
   const [info, setInfo] = useState({ tags: "" });
   const [showTagPills, setShowTagPills] = useState(false);
-  // const [inputValue, setInputValue] = useState(""); //Trying not to use this state####################################
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -71,10 +70,6 @@ export default function SearchBar() {
       : tagStyles.inactiveTag;
 
   const handleUserInput = (e) => {
-    //Remove these two lines now that we're not using the inputValue state#################
-    // const newValue = e.target.value;
-    // setInputValue(newValue);
-    //##################################################################
     if (validateSearchText(e.target.value)) {
       baseHandleUserInput(e);
     }
@@ -110,14 +105,11 @@ export default function SearchBar() {
   };
 
   const handleReset = () => {
-    // setInputValue(""); //Not using this state###################################
-    console.log("handleReset was called");
 
     if (searchInputRef.current) {
       searchInputRef.current.value = "";
     }
 
-    console.log("Calling baseHandleUserInput with an empty string");
     baseHandleUserInput({ target: { value: "" } });
 
     clearAllTags();

--- a/front-end/src/hooks/useSearchResources.js
+++ b/front-end/src/hooks/useSearchResources.js
@@ -17,7 +17,6 @@ export default function useSearchResources({ resources, tags, isFetching }) {
   const [results, setResults] = useState(null);
 
   const handleUserInput = (e) => {
-    console.log("baseHandleUserInput called")
     const refactoredTags = activeTags.map(({ id }) => id);
     setUserInput({ keywords: e.target.value, tags: refactoredTags });
   };


### PR DESCRIPTION
The issue of the pagination menu getting pushed off the page was corrected by slightly shortening the container element containing the results for the various screen sizes.

Also removed a few console.log lines and commented out code to clean up the code a little bit.